### PR TITLE
use int instead of bytes as type hint.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -261,10 +261,10 @@ Returns:<br>
 Returns:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;int:&nbsp;0&nbsp;for&nbsp;no,&nbsp;1&nbsp;for&nbsp;yes&nbsp;and&nbsp;2&nbsp;for&nbsp;irrelevant?.</tt></dd></dl>
 
-<dl><dt><a name="MCP2221-i2c_read_data"><strong>i2c_read_data</strong></a>(self, address: bytes, length: int, i2c_mode: mcp2221.enums.I2CMode = &lt;I2CMode.Start: 144&gt;) -&gt; bytearray</dt><dd><tt>Reads&nbsp;data&nbsp;from&nbsp;given&nbsp;I2C&nbsp;address.<br>
+<dl><dt><a name="MCP2221-i2c_read_data"><strong>i2c_read_data</strong></a>(self, address: int, length: int, i2c_mode: mcp2221.enums.I2CMode = &lt;I2CMode.Start: 144&gt;) -&gt; bytearray</dt><dd><tt>Reads&nbsp;data&nbsp;from&nbsp;given&nbsp;I2C&nbsp;address.<br>
 &nbsp;<br>
 Parameters:<br>
-&nbsp;&nbsp;&nbsp;&nbsp;address(bytes):&nbsp;7-bit&nbsp;I2C&nbsp;slave&nbsp;address<br>
+&nbsp;&nbsp;&nbsp;&nbsp;address(int):&nbsp;7-bit&nbsp;I2C&nbsp;slave&nbsp;address<br>
 &nbsp;&nbsp;&nbsp;&nbsp;length(int):&nbsp;amount&nbsp;of&nbsp;data&nbsp;to&nbsp;read<br>
 &nbsp;&nbsp;&nbsp;&nbsp;i2c_mode(I2CMode):&nbsp;enum&nbsp;code&nbsp;for&nbsp;I2C&nbsp;mode<br>
 &nbsp;<br>
@@ -276,10 +276,10 @@ Returns:<br>
 Returns:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;I2CSpeed:&nbsp;enum&nbsp;code&nbsp;describing&nbsp;current&nbsp;I2C&nbsp;speed.</tt></dd></dl>
 
-<dl><dt><a name="MCP2221-i2c_write_data"><strong>i2c_write_data</strong></a>(self, address: bytes, data: str, i2c_mode: mcp2221.enums.I2CMode = &lt;I2CMode.Start: 144&gt;) -&gt; None</dt><dd><tt>Writes&nbsp;data&nbsp;to&nbsp;given&nbsp;I2C&nbsp;address.<br>
+<dl><dt><a name="MCP2221-i2c_write_data"><strong>i2c_write_data</strong></a>(self, address: int, data: str, i2c_mode: mcp2221.enums.I2CMode = &lt;I2CMode.Start: 144&gt;) -&gt; None</dt><dd><tt>Writes&nbsp;data&nbsp;to&nbsp;given&nbsp;I2C&nbsp;address.<br>
 &nbsp;<br>
 Parameters:<br>
-&nbsp;&nbsp;&nbsp;&nbsp;address(bytes):&nbsp;7-bit&nbsp;I2C&nbsp;slave&nbsp;address<br>
+&nbsp;&nbsp;&nbsp;&nbsp;address(int):&nbsp;7-bit&nbsp;I2C&nbsp;slave&nbsp;address<br>
 &nbsp;&nbsp;&nbsp;&nbsp;data(str):&nbsp;data&nbsp;string<br>
 &nbsp;&nbsp;&nbsp;&nbsp;i2c_mode(I2CMode):&nbsp;enum&nbsp;code&nbsp;for&nbsp;I2C&nbsp;mode</tt></dd></dl>
 

--- a/mcp2221/__init__.py
+++ b/mcp2221/__init__.py
@@ -1101,11 +1101,11 @@ class MCP2221():
         """
         return self._write(0x10)[25]
 
-    def _check_i2c_parameters(self, address:bytes, length:int):
+    def _check_i2c_parameters(self, address:int, length:int):
         """Internal command. Checks if given I2C parameters are valid.
 
         Parameters:
-            address(bytes): 7-bit I2C slave address
+            address(int): 7-bit I2C slave address
             length(int): data string length (max. 65535 characters)
         
         Raises:
@@ -1117,11 +1117,11 @@ class MCP2221():
         if length > 0xffff:
             raise InvalidParameterException("Data string too long.")
 
-    def i2c_write_data(self, address:bytes, data:bytearray, i2c_mode:I2CMode = I2CMode.Start) -> None:
+    def i2c_write_data(self, address:int, data:bytearray, i2c_mode:I2CMode = I2CMode.Start) -> None:
         """Writes data to given I2C address.
 
         Parameters:
-            address(bytes): 7-bit I2C slave address
+            address(int): 7-bit I2C slave address
             data(str): data string
             i2c_mode(I2CMode): enum code for I2C mode
         """
@@ -1136,11 +1136,11 @@ class MCP2221():
                 if ret[1] == 0: break
             rem_bytes -= chunk_len
 
-    def i2c_read_data(self, address:bytes, length:int, i2c_mode:I2CMode = I2CMode.Start) -> bytearray:
+    def i2c_read_data(self, address:int, length:int, i2c_mode:I2CMode = I2CMode.Start) -> bytearray:
         """Reads data from given I2C address.
 
         Parameters:
-            address(bytes): 7-bit I2C slave address
+            address(int): 7-bit I2C slave address
             length(int): amount of data to read
             i2c_mode(I2CMode): enum code for I2C mode
         


### PR DESCRIPTION
The i2c commands needs the address as int type. Otherwise it will raise errors like

TypeError: '<' not supported between instances of 'bytes' and 'int'
TypeError: unsupported operand type(s) for <<: 'bytes' and 'int'

No functional change.